### PR TITLE
fix mislined entry box and label text

### DIFF
--- a/instamatic/gui/debug_frame.py
+++ b/instamatic/gui/debug_frame.py
@@ -74,15 +74,15 @@ class DebugFrame(LabelFrame):
 
         Label(frame, text='Space group: ').grid(row=4, column=2, sticky='EW')
         self.e_sg = Entry(frame, textvariable=self.var_e_sg, width=15, state=DISABLED)
-        self.e_sg.grid(row=5, column=3, sticky='EW', columnspan=2)
+        self.e_sg.grid(row=4, column=3, sticky='EW', columnspan=2)
 
         Label(frame, text='Unit cell: ').grid(row=5, column=2, sticky='EW')
         self.e_uc = Entry(frame, textvariable=self.var_e_uc, width=15, state=DISABLED)
-        self.e_uc.grid(row=6, column=3, sticky='EW')
+        self.e_uc.grid(row=5, column=3, sticky='EW')
 
         Label(frame, text='Composition: ').grid(row=6, column=2, sticky='EW')
         self.e_compo = Entry(frame, textvariable=self.var_e_compo, width=15, state=DISABLED)
-        self.e_compo.grid(row=4, column=3, sticky='EW', columnspan=1)
+        self.e_compo.grid(row=6, column=3, sticky='EW', columnspan=1)
 
         frame.columnconfigure(0, weight=1)
         frame.pack(side='top', fill='x', padx=10, pady=10)


### PR DESCRIPTION
In debug_frame the label and text entry boxes appeared to be misaligned